### PR TITLE
Compile with UTF-8 & Release native objects.

### DIFF
--- a/buildAndRun.bat
+++ b/buildAndRun.bat
@@ -27,7 +27,8 @@ javac ^
     -cp %LIBS_DIR%\*.jar ^
 	-d "%BIN_DIR%" ^
 	-sourcepath %SRC_DIR% ^
-	"%SRC_DIR%\%APP_STARTER_DIR%\%APP_STARTER%.java"
+	"%SRC_DIR%\%APP_STARTER_DIR%\%APP_STARTER%.java" ^
+	-encoding utf8
 
 if errorlevel 1 (
 	echo compile:error

--- a/src/net/bowen/EdgeDetection.java
+++ b/src/net/bowen/EdgeDetection.java
@@ -15,7 +15,6 @@ public class EdgeDetection extends JFrame {
      * Reference: https://chtseng.wordpress.com/2016/12/05/opencv-edge-detection%E9%82%8A%E7%B7%A3%E5%81%B5%E6%B8%AC/
      * */
     public EdgeDetection() {
-        // TODO: 2023/11/8 Release native objects in this class.
         // Prepare fot image
         Mat src = Imgcodecs.imread("resources/pictures/houmai.jpg");
         Imgproc.resize(src, src, new Size(), .8, .8);
@@ -23,10 +22,12 @@ public class EdgeDetection extends JFrame {
         // Turn to gray scale
         Mat grayScale = new Mat();
         Imgproc.cvtColor(src, grayScale, Imgproc.COLOR_BGR2GRAY);
+	src.release();
 
         // Apply Laplacian edge detection
         Mat finalImg = new Mat();
         Imgproc.Laplacian(grayScale, finalImg, CvType.CV_16S, 3, 1, 0, Core.BORDER_DEFAULT);
+	grayScale.release();
 
         // converting back to CV_8U
         Core.convertScaleAbs(finalImg, finalImg);
@@ -34,9 +35,12 @@ public class EdgeDetection extends JFrame {
         // Convert img to bufferedImage
         MatOfByte matOfByte = new MatOfByte();
         Imgcodecs.imencode(".jpg", finalImg, matOfByte);
+	finalImg.release();
+
         BufferedImage bufferedImage;
         try {
             bufferedImage = ImageIO.read(new ByteArrayInputStream(matOfByte.toArray()));
+	    matOfByte.release();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -44,7 +48,7 @@ public class EdgeDetection extends JFrame {
         // Prepare for window
         setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         setResizable(false);
-        setSize(src.width(), src.height());
+        setSize(bufferedImage.getWidth(), bufferedImage.getHeight());
         setTitle("Edge Detection");
         add(new JLabel(new ImageIcon(bufferedImage)));
         setVisible(true);


### PR DESCRIPTION
Without specifying javac encoding argument to utf-8, compile won't success on some machines. So added that.
I also finish the native objects releasing TODO.